### PR TITLE
fix: empty `var=` assignment swallowing the next statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1829,7 +1829,7 @@ module.exports = grammar({
 
     comment: $ => token(prec(-20, /#[^\r\n]*/)),
 
-    _comment_word: _ => token(prec(-8, seq(
+    _comment_word: _ => token.immediate(prec(-8, seq(
       choice(
         noneOf(...SPECIAL_CHARACTERS),
         seq('\\', noneOf('\\s')),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10701,7 +10701,7 @@
       }
     },
     "_comment_word": {
-      "type": "TOKEN",
+      "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PREC",
         "value": -8,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -704,6 +704,20 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
     bool was_just_newline = scanner->just_newline;
     scanner->just_newline = false;
 
+    // Empty assignment value (`var=` followed by whitespace/newline/terminator).
+    // Must run BEFORE the BARE_DOLLAR handler below, which skips whitespace+newlines
+    // hunting for a `$` and would otherwise consume the newline after `=`, letting a
+    // word on a later line be grabbed as the value. In zsh, any whitespace after `=`
+    // means the value is empty.
+    if (valid_symbols[EMPTY_VALUE] && !in_error_recovery(valid_symbols) &&
+        (iswspace(lexer->lookahead) || lexer->eof(lexer) ||
+         lexer->lookahead == ';' || lexer->lookahead == '&' ||
+         lexer->lookahead == '}')) {
+        lexer->mark_end(lexer);
+        lexer->result_symbol = EMPTY_VALUE;
+        return true;
+    }
+
     if ((valid_symbols[CONCAT] || valid_symbols[CONCAT_REGEX]) &&
         !in_error_recovery(valid_symbols)) {
         context_type_t ctx = get_current_context(scanner);
@@ -1470,16 +1484,6 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
             lexer->result_symbol = ARRAY_AT_TOKEN;
             advance(lexer);
             lexer->mark_end(lexer);
-            return true;
-        }
-    }
-
-    if (valid_symbols[EMPTY_VALUE]) {
-        if (iswspace(lexer->lookahead) || lexer->eof(lexer) ||
-            lexer->lookahead == ';' || lexer->lookahead == '&' ||
-            lexer->lookahead == '}') {
-            lexer->mark_end(lexer);
-            lexer->result_symbol = EMPTY_VALUE;
             return true;
         }
     }

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1791,4 +1791,56 @@ echo ok
       (word))
     argument: (word)))
 
+==================================================
+Empty variable assignment then comment with apostrophe (regression)
+==================================================
+
+x=
+# it's a comment
+
+----------
+
+(program
+  (variable_assignment
+    name: (variable_name))
+  (comment))
+
+==================================================
+Adjacent hash value with apostrophe in trailing comment (regression)
+==================================================
+
+var=#not-comment # legit's comment
+
+----------
+
+(program
+  (variable_assignment
+    name: (variable_name)
+    value: (word))
+  (comment))
+
+==================================================
+Empty assignment value does not swallow the next statement (regression)
+==================================================
+
+f() {
+  local x=
+  if true; then
+  fi
+}
+
+----------
+
+(program
+  (function_definition
+    name: (word)
+    body: (compound_statement
+      (declaration_command
+        (variable_assignment
+          name: (variable_name)))
+      (if_statement
+        condition: (command
+          name: (command_name
+            (word)))))))
+
 


### PR DESCRIPTION
Two related bugs around empty assignments:

1. `x=` at the end of a line swallowed the first word of the next statement as its value. Root cause is in the scanner: the BARE_DOLLAR handler skips whitespace *and newlines* hunting for a `$` before the EMPTY_VALUE check gets a chance to run, so the newline after `=` was consumed. Moved the EMPTY_VALUE check to the top of `scan()`, with the same `!in_error_recovery` guard the neighboring handlers use.

2. A `#` comment on the line after an empty assignment was parsed as the assignment's value up to the first `'`, which opened an unterminated raw_string and ERROR'd everything below it. `_comment_word` is now `token.immediate` so a `#`-leading value only binds when directly adjacent to `=` (`var=#foo` still parses as before).

Found while editing my zshrc — this snippet ERROR'd across the whole block:

```zsh
local f avail restore=
# it's a comment
if true; then
fi
```

Three corpus regression tests added, suite green. Generated files rebuilt with the pinned tree-sitter-cli (0.25.x), so `src/tree_sitter/` is untouched.
