### PR TITLE
fix: never emit zero-width REGEX_NO_SLASH token (incremental-parse OOM)

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2114,6 +2114,15 @@ regex:
 #endif
                 return false;
             }
+            if (valid_symbols[REGEX_NO_SLASH] && !state.advanced_once) {
+                // Never emit a zero-width token: the parser makes no
+                // progress and loops forever growing the tree.
+
+#if DEBUG
+                fprintf(stderr, "DEBUG: regex not valid returning false\n");
+#endif
+                return false;
+            }
 
 #if DEBUG
             fprintf(stderr, "DEBUG: regex scan returning regex\n");


### PR DESCRIPTION
## Summary

The external scanner's post-scan zero-width guards cover `REGEX` and `REGEX_NO_SPACE`, but not `REGEX_NO_SLASH`. When the parser requests a pattern token in a `${var/pattern/repl}` context while the lexer is sitting on a closing delimiter at depth 0, the scan loop sets `done` on the first iteration without consuming any input, and the scanner returns a zero-width `REGEX_NO_SLASH` token. The parser shifts it, the repeat rule (`_concatenation_in_expansion_regex_no_slash_repeat1`) requests another token from the same position, and the cycle repeats without advancing — unbounded tree growth until the process is OOM-killed. In Neovim this manifests as the editor allocating all available RAM while typing.

## Reproduction

Parse:

~~~zsh
print -- ${${(%):-'%D{%Y-%m-%dT%H:%M:%S.%N}'}/%(#b
~~~

then insert the `)` (completing `%(#b)`) via `ts_tree_edit` and reparse incrementally. A from-scratch parse of the full line is unaffected; the bug requires the incremental path. Also reproducible by simply typing the line in any editor with incremental parsing enabled.

With `TSLogger` attached, the death loop is visible directly:

~~~
[parse] lex_external state:275 ... lexed_lookahead sym:regex, size:0
[parse] lex_external state:296 ... lexed_lookahead sym:_concat, size:0
[parse] reduce sym:_concatenation_in_expansion_regex_no_slash_repeat1 ...
(repeats forever at the same row/col)
~~~

## Fix

Add the same `!state.advanced_once → return false` guard that `REGEX` and `REGEX_NO_SPACE` already have.

## Testing

- `tree-sitter test`: 143/143 pass.
- The repro above completes instantly with the fix; a harness inserting a character at every position of the trigger line via `ts_tree_edit` finds no other looping position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)